### PR TITLE
Rechtschreibfehler gefixt und command cxn fähig gemacht

### DIFF
--- a/BrauchtSkBee/discord.sk
+++ b/BrauchtSkBee/discord.sk
@@ -1,8 +1,8 @@
 function discord(player: player):
-	set {_t} to text component from "&3Um unserem &9Discord &3 zu joinen klicke &r[&aHier&r]"
+	set {_t} to text component from "&3Um unserem &9Discord &3zu joinen klicke &r[&aHier&r]"
 	add hover event showing "Joine dem Discord" to {_t}
 	add click event to open url "https://discord.gg/DEINEDISCORDINVITE" to {_t}
 	send component {_t} to {_player}
-command /discord:
+command /rdiscord:
 	trigger:
 		discord(player)


### PR DESCRIPTION
## discord.sk
- Rechtschreibfehler in Zeile 2 (doppeltes Leerzeichen) gefixt
- CXN blockt die cmds /discord und /cd, meist nutzt man die cmds mit einem "r" davor (steht für "Realm")